### PR TITLE
Potential fix for code scanning alert no. 114: DOM text reinterpreted as HTML

### DIFF
--- a/wp-admin/js/nav-menu.js
+++ b/wp-admin/js/nav-menu.js
@@ -1292,8 +1292,8 @@
 				if ( this.checked === true ) {
 					$( '#pending-menu-items-to-delete ul' ).append(
 						'<li data-menu-item-id="' + menuItemID + '">' +
-							'<span class="pending-menu-item-name">' + menuItemName + '</span> ' +
-							'<span class="pending-menu-item-type">(' + menuItemType + ')</span>' +
+							'<span class="pending-menu-item-name">' + wp.html.escape(menuItemName) + '</span> ' +
+							'<span class="pending-menu-item-type">(' + wp.html.escape(menuItemType) + ')</span>' +
 							'<span class="separator"></span>' +
 						'</li>'
 					);


### PR DESCRIPTION
Potential fix for [https://github.com/nicolascerroverde/war-santa-rosa/security/code-scanning/114](https://github.com/nicolascerroverde/war-santa-rosa/security/code-scanning/114)

To fix the issue, the untrusted text (`menuItemName`) must be sanitized or escaped before being concatenated into the HTML string. The best approach is to use a library or built-in function to escape special HTML characters, ensuring that the text is treated as plain text rather than HTML. In this case, WordPress provides a utility function `wp.html.escape()` that can be used to escape the text safely.

The fix involves replacing the concatenation of `menuItemName` with its escaped version using `wp.html.escape(menuItemName)`. This ensures that any special characters in `menuItemName` are properly encoded, preventing them from being interpreted as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
